### PR TITLE
Add ability to specify "when" attribute

### DIFF
--- a/src/commands/copy.yml
+++ b/src/commands/copy.yml
@@ -24,11 +24,17 @@ parameters:
     type: env_var_name
     description: aws region override
     default: AWS_REGION
+  when:
+    type: string
+    description: 'equivalent to the "when" attribute of job steps'
+    default: 'on_success'
 steps:
   - aws-cli/setup:
       aws-access-key-id: << parameters.aws-access-key-id >>
       aws-secret-access-key: << parameters.aws-secret-access-key >>
       aws-region: << parameters.aws-region >>
+      when: << parameters.when >>
   - run:
       name: S3 Copy << parameters.from >> -> << parameters.to >>
       command: "aws s3 cp << parameters.from >> << parameters.to >><<# parameters.arguments >> << parameters.arguments >><</ parameters.arguments >>"
+      when: << parameters.when >>

--- a/src/commands/sync.yml
+++ b/src/commands/sync.yml
@@ -32,14 +32,20 @@ parameters:
     type: env_var_name
     description: aws region override
     default: AWS_REGION
+  when:
+    type: string
+    description: 'equivalent to the "when" attribute of job steps'
+    default: 'on_success'
 steps:
   - aws-cli/setup:
       aws-access-key-id: << parameters.aws-access-key-id >>
       aws-secret-access-key: << parameters.aws-secret-access-key >>
       aws-region: << parameters.aws-region >>
+      when: << parameters.when >>
   - deploy:
       name: S3 Sync
       command: |
         aws s3 sync \
           <<parameters.from>> <<parameters.to>><<#parameters.overwrite>> --delete<</parameters.overwrite>><<#parameters.arguments>> \
           <<parameters.arguments>><</parameters.arguments>>
+      when: << parameters.when >>

--- a/src/examples/always.yml
+++ b/src/examples/always.yml
@@ -1,0 +1,17 @@
+description: >
+  You may direct the S3 orb to always run, regardless of previous steps status
+usage:
+  version: 2.1
+  orbs:
+    aws-s3: circleci/aws-s3@x.y
+  jobs:
+    build:
+      docker:
+        - image: cimg/python:3.6
+      steps:
+        - checkout
+        - run: mkdir bucket && echo "lorem ipsum" > bucket/build_asset.txt
+        - aws-s3/copy:
+            from: bucket/build_asset.txt
+            to: "s3://my-s3-bucket-name"
+            when: always


### PR DESCRIPTION
### Checklist

<!--
  Thank you for contributing to CircleCI Orbs!
  before submitting your request, please go through the following
  items and place an x in the [ ] if they have been completed.
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, Related Issues

<!---
  Why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

The main motivation comes from the [following idea ticket](https://ideas.circleci.com/ideas/CCI-I-1360)

Basically I'd need my S3 steps to always run (when: 'always'), but this is currently not supported by the orb ecosystem.
### Description

<!---
  Describe your changes in details, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
-->

This PR adds a "when" parameter to the S3 orb and simply pass it to its steps, which solves the aforementioned problem.

See also [related PR in aws-cli-orb repository](https://github.com/CircleCI-Public/aws-cli-orb/pull/35)