### PR TITLE
[semver:patch] Revert "Example correction --dry-run"

### DIFF
--- a/src/examples/override_credentials.yml
+++ b/src/examples/override_credentials.yml
@@ -24,4 +24,4 @@ usage:
         - aws-s3/copy:
             from: bucket/build_asset.txt
             to: "s3://my-s3-bucket-name"
-            arguments: --dry-run
+            arguments: --dryrun

--- a/src/examples/sync_and_copy.yml
+++ b/src/examples/sync_and_copy.yml
@@ -21,4 +21,4 @@ usage:
         - aws-s3/copy:
             from: bucket/build_asset.txt
             to: "s3://my-s3-bucket-name"
-            arguments: --dry-run
+            arguments: --dryrun


### PR DESCRIPTION
The exact spelling of the "dry run" option is dependent on the aws command used. In the case of `aws s3 cp` the spelling is `--dryrun` [(see docs)][1]. The originally cited change (#2 / https://github.com/CircleCI-Public/circleci-orbs/issues/272 ) used the spelling used by `aws ec2 describe-instances` [(see docs)][2].

I assume the docs at https://circleci.com/orbs/registry/orb/circleci/aws-s3 will be updated by this PR? 

[1]: https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3/cp.html#options

[2]: https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instances.html#options