### PR TITLE
Python fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,18 @@ jobs:
       - aws-s3/copy:
           from: bucket/build_asset.txt
           to: "s3://orb-testing"
+  integration-test-2:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - run: mkdir bucket && echo "lorem ipsum" > bucket/build_asset.txt
+      - aws-s3/sync:
+          from: bucket
+          to: "s3://orb-testing/s3-orb"
+      - aws-s3/copy:
+          from: bucket/build_asset.txt
+          to: "s3://orb-testing"
 
 workflows:
   # This `lint-pack_validate_publish-dev` workflow will run on any commit.
@@ -82,6 +94,7 @@ workflows:
 
       # Run Copy and Sync commands. Requires credentials. These are already set in the CircleCI Project
       - integration-test-1
+      - integration-test-2
 
       # publish a semver version of the orb. relies on
       # the commit subject containing the text "[semver:patch|minor|major|skip]"
@@ -99,6 +112,7 @@ workflows:
           publish-version-tag: false
           requires:
             - integration-test-1
+            - integration-test-2
           filters:
             branches:
               only: master

--- a/src/commands/copy.yml
+++ b/src/commands/copy.yml
@@ -25,6 +25,14 @@ parameters:
     description: aws region override
     default: AWS_REGION
 steps:
+  - run:
+      name: "Pip Check"
+      command: |
+        # This can likley be removed once this orb exclusively uses the
+        # AWS CLI v2 which bundles its own Python.
+        if ! which pip3;then
+          sudo apt-get update && sudo apt-get install -y python3-pip
+        fi
   - aws-cli/setup:
       aws-access-key-id: << parameters.aws-access-key-id >>
       aws-secret-access-key: << parameters.aws-secret-access-key >>

--- a/src/commands/sync.yml
+++ b/src/commands/sync.yml
@@ -30,6 +30,14 @@ parameters:
     description: aws region override
     default: AWS_REGION
 steps:
+  - run:
+      name: "Pip Check"
+      command: |
+        # This can likley be removed once this orb exclusively uses the
+        # AWS CLI v2 which bundles its own Python.
+        if ! which pip3;then
+          sudo apt-get update && sudo apt-get install -y python3-pip
+        fi
   - aws-cli/setup:
       aws-access-key-id: << parameters.aws-access-key-id >>
       aws-secret-access-key: << parameters.aws-secret-access-key >>


### PR DESCRIPTION
Fixes #12 

This PR contains two commits.

1. Adds an additional int test to test the orb with the base image. This should help catch issues like #12 earlier.
2. Test and optionally installs pip. This is what's missing in images not `cimg/python` which was failing.


I consider this PR to be a patch fix for the current issue. The longer fix, in a major change, will be to utilize the AWS CLI v2 which bundles its own Python and means we can avoid Python 2 vs Python 3 issues completely.