### PR TITLE
Upgrade to AWS CLI v2 and remove pip check [semver:major]

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -9,4 +9,4 @@ display:
   source_url: https://github.com/CircleCI-Public/aws-s3-orb
 
 orbs:
-  aws-cli: circleci/aws-cli@0.1
+  aws-cli: circleci/aws-cli@1.3.0

--- a/src/commands/copy.yml
+++ b/src/commands/copy.yml
@@ -25,14 +25,6 @@ parameters:
     description: aws region override
     default: AWS_REGION
 steps:
-  - run:
-      name: "Pip Check"
-      command: |
-        # This can likley be removed once this orb exclusively uses the
-        # AWS CLI v2 which bundles its own Python.
-        if ! which pip3;then
-          sudo apt-get update && sudo apt-get install -y python3-pip
-        fi
   - aws-cli/setup:
       aws-access-key-id: << parameters.aws-access-key-id >>
       aws-secret-access-key: << parameters.aws-secret-access-key >>

--- a/src/commands/sync.yml
+++ b/src/commands/sync.yml
@@ -30,14 +30,6 @@ parameters:
     description: aws region override
     default: AWS_REGION
 steps:
-  - run:
-      name: "Pip Check"
-      command: |
-        # This can likley be removed once this orb exclusively uses the
-        # AWS CLI v2 which bundles its own Python.
-        if ! which pip3;then
-          sudo apt-get update && sudo apt-get install -y python3-pip
-        fi
   - aws-cli/setup:
       aws-access-key-id: << parameters.aws-access-key-id >>
       aws-secret-access-key: << parameters.aws-secret-access-key >>


### PR DESCRIPTION
I've updated the orb config file to point to the aws-cli 1.3.0 orb, which
uses the new AWS CLI v2. I've removed the pip check command as the new CLI
comes packaged with Python already, and the aws-cli orb also does its own check.

Based on comments in other issues, this will be considered a major release.

Closes #15.