### PR TITLE
[semver:minor] Add new param for skip aws setup:

### DIFF
--- a/src/commands/copy.yml
+++ b/src/commands/copy.yml
@@ -9,7 +9,7 @@ parameters:
     description: A local target or s3 destination
   arguments:
     description: If you wish to pass any additional arguments to the aws copy command (i.e. -sse)
-    default: ''
+    default: ""
     type: string
   aws-access-key-id:
     type: env_var_name
@@ -23,18 +23,18 @@ parameters:
     type: env_var_name
     description: aws region override
     default: AWS_REGION
-  aws-skip-setup:
+  install-aws-cli:
     type: boolean
-    description: Skip aws cli setup. Useful when you're using profiles
-    default: false
+    description: Install aws cli setup. By default true Useful when you're using profiles
+    default: true
 steps:
-  - unless:
-          condition: << parameters.aws-skip-setup >>
-          steps:
-            - aws-cli/setup:
-                aws-access-key-id: << parameters.aws-access-key-id >>
-                aws-secret-access-key: << parameters.aws-secret-access-key >>
-                aws-region: << parameters.aws-region >>
+  - when:
+      condition: << parameters.install-aws-cli >>
+      steps:
+        - aws-cli/setup:
+            aws-access-key-id: << parameters.aws-access-key-id >>
+            aws-secret-access-key: << parameters.aws-secret-access-key >>
+            aws-region: << parameters.aws-region >>
   - run:
       name: S3 Copy << parameters.from >> -> << parameters.to >>
       command: "aws s3 cp << parameters.from >> << parameters.to >><<# parameters.arguments >> << parameters.arguments >><</ parameters.arguments >>"

--- a/src/commands/copy.yml
+++ b/src/commands/copy.yml
@@ -25,7 +25,10 @@ parameters:
     default: AWS_REGION
   install-aws-cli:
     type: boolean
-    description: Install aws cli setup. By default true Useful when you're using profiles
+    description: >
+      Install aws cli. 
+      By default true. 
+      Useful when you're using aws-cli profiles
     default: true
 steps:
   - when:

--- a/src/commands/copy.yml
+++ b/src/commands/copy.yml
@@ -23,11 +23,18 @@ parameters:
     type: env_var_name
     description: aws region override
     default: AWS_REGION
+  aws-skip-setup:
+    type: boolean
+    description: Skip aws cli setup. Useful when you're using profiles
+    default: false
 steps:
-  - aws-cli/setup:
-      aws-access-key-id: << parameters.aws-access-key-id >>
-      aws-secret-access-key: << parameters.aws-secret-access-key >>
-      aws-region: << parameters.aws-region >>
+  - unless:
+          condition: << parameters.aws-skip-setup >>
+          steps:
+            - aws-cli/setup:
+                aws-access-key-id: << parameters.aws-access-key-id >>
+                aws-secret-access-key: << parameters.aws-secret-access-key >>
+                aws-region: << parameters.aws-region >>
   - run:
       name: S3 Copy << parameters.from >> -> << parameters.to >>
       command: "aws s3 cp << parameters.from >> << parameters.to >><<# parameters.arguments >> << parameters.arguments >><</ parameters.arguments >>"

--- a/src/commands/sync.yml
+++ b/src/commands/sync.yml
@@ -30,7 +30,10 @@ parameters:
     default: AWS_REGION
   install-aws-cli:
     type: boolean
-    description: Install aws cli setup. By default true Useful when you're using profiles
+    description: >
+      Install aws cli. 
+      By default true. 
+      Useful when you're using aws-cli profiles
     default: true
 steps:
   - when:

--- a/src/commands/sync.yml
+++ b/src/commands/sync.yml
@@ -28,11 +28,18 @@ parameters:
     type: env_var_name
     description: aws region override
     default: AWS_REGION
+  aws-skip-setup:
+    type: boolean
+    description: Skip aws cli setup. Useful when you're using profiles
+    default: false    
 steps:
-  - aws-cli/setup:
-      aws-access-key-id: << parameters.aws-access-key-id >>
-      aws-secret-access-key: << parameters.aws-secret-access-key >>
-      aws-region: << parameters.aws-region >>
+  - unless:
+          condition: << parameters.aws-skip-setup >>
+          steps:
+            - aws-cli/setup:
+                aws-access-key-id: << parameters.aws-access-key-id >>
+                aws-secret-access-key: << parameters.aws-secret-access-key >>
+                aws-region: << parameters.aws-region >>
   - deploy:
       name: S3 Sync
       command: |

--- a/src/commands/sync.yml
+++ b/src/commands/sync.yml
@@ -28,18 +28,18 @@ parameters:
     type: env_var_name
     description: aws region override
     default: AWS_REGION
-  aws-skip-setup:
+  install-aws-cli:
     type: boolean
-    description: Skip aws cli setup. Useful when you're using profiles
-    default: false    
+    description: Install aws cli setup. By default true Useful when you're using profiles
+    default: true
 steps:
-  - unless:
-          condition: << parameters.aws-skip-setup >>
-          steps:
-            - aws-cli/setup:
-                aws-access-key-id: << parameters.aws-access-key-id >>
-                aws-secret-access-key: << parameters.aws-secret-access-key >>
-                aws-region: << parameters.aws-region >>
+  - when:
+      condition: << parameters.install-aws-cli >>
+      steps:
+        - aws-cli/setup:
+            aws-access-key-id: << parameters.aws-access-key-id >>
+            aws-secret-access-key: << parameters.aws-secret-access-key >>
+            aws-region: << parameters.aws-region >>
   - deploy:
       name: S3 Sync
       command: |

--- a/src/examples/skip_aws_setup_using_profiles.yml
+++ b/src/examples/skip_aws_setup_using_profiles.yml
@@ -19,7 +19,7 @@ usage:
             source-profile: default        
           - run: mkdir bucket && echo "lorem ipsum" > bucket/build_asset.txt
           - aws-s3/sync:
-              aws-skip-setup: true
+              install-aws-cli: false
               from: bucket
               to: "s3://my-s3-bucket-name/prefix"
               arguments: |
@@ -27,7 +27,7 @@ usage:
                 --cache-control "max-age=86400"
                 --profile new-profile
           - aws-s3/copy:
-              aws-skip-setup: true
+              install-aws-cli: false
               from: bucket/build_asset.txt
               to: "s3://my-s3-bucket-name"
               arguments: |

--- a/src/examples/skip_aws_setup_using_profiles.yml
+++ b/src/examples/skip_aws_setup_using_profiles.yml
@@ -1,0 +1,39 @@
+description: >
+  use the S3 orb by using aws profile setup. The example below shows copy a file to an S3 bucket using an AWS cli profile. 
+usage:
+  version: 2.1
+  orbs:
+    aws-s3: circleci/aws-s3@3.1
+    aws-cli: circleci/aws-cli@3.1
+  jobs:
+    build:
+      docker:
+        - image: cimg/python:3.6
+      steps:
+        - checkout
+        - aws-cli/setup:
+            profile-name: default
+        - aws-cli/role-arn-setup:
+            profile-name: new-profile
+            role-arn: 'arn:aws:iam::123456789012:role/example-role'
+            source-profile: default        
+          - run: mkdir bucket && echo "lorem ipsum" > bucket/build_asset.txt
+          - aws-s3/sync:
+              aws-skip-setup: true
+              from: bucket
+              to: "s3://my-s3-bucket-name/prefix"
+              arguments: |
+                --acl public-read \
+                --cache-control "max-age=86400"
+                --profile new-profile
+          - aws-s3/copy:
+              aws-skip-setup: true
+              from: bucket/build_asset.txt
+              to: "s3://my-s3-bucket-name"
+              arguments: |
+                --dryrun
+                --profile new-profile
+  workflows:
+    s3-example:
+      jobs:
+        - build


### PR DESCRIPTION
## Add optional aws-cli setup 

Reported Issue #29 

- Add a flag to `install-aws-cli`. When you're using profiles configuration for aws-cli this orb overrides the setup making it useless. This flag helps to skip the aws-setup to use the defined at the working pipeline 
- Added example of how to use this flag. 