### PR TITLE
feat: oidc implementation

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -15,9 +15,11 @@ jobs:
       - aws-s3/sync:
           from: bucket
           to: "s3://orb-testing-1/s3-orb"
+          role-arn: arn:aws:iam::122211685980:role/CPE_S3_OIDC_TEST
       - aws-s3/copy:
           from: bucket/build_asset.txt
           to: "s3://orb-testing-1"
+          role-arn: arn:aws:iam::122211685980:role/CPE_S3_OIDC_TEST          
   integration-test-2:
     docker:
       - image: cimg/base:stable
@@ -27,9 +29,11 @@ jobs:
       - aws-s3/sync:
           from: bucket
           to: "s3://orb-testing-1/s3-orb"
+          role-arn: arn:aws:iam::122211685980:role/CPE_S3_OIDC_TEST
       - aws-s3/copy:
           from: bucket/build_asset.txt
           to: "s3://orb-testing-1"
+          role-arn: arn:aws:iam::122211685980:role/CPE_S3_OIDC_TEST
 workflows:
   test-deploy:
     jobs:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -39,10 +39,10 @@ workflows:
     jobs:
       # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
       - integration-test-1:
-          context: [CPE_ORBS_AWS]
+          context: [CPE-OIDC]
           filters: *filters
       - integration-test-2:
-          context: [CPE_ORBS_AWS]
+          context: [CPE-OIDC]
           filters: *filters
       - orb-tools/pack:
           filters: *filters

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -9,4 +9,4 @@ display:
   source_url: https://github.com/CircleCI-Public/aws-s3-orb
 
 orbs:
-  aws-cli: circleci/aws-cli@2.0
+  aws-cli: circleci/aws-cli@3.1

--- a/src/commands/copy.yml
+++ b/src/commands/copy.yml
@@ -23,11 +23,42 @@ parameters:
     type: env_var_name
     description: aws region override
     default: AWS_REGION
+  profile-name:
+    description: AWS profile name to be configured.
+    type: string
+    default: ''
+  role-arn:
+    description: |
+      The Amazon Resource Name (ARN) of the role that the caller is assuming.
+      Role ARN must be configured for web identity.
+    type: string
+    default: ""
+  role-session-name:
+    description: An identifier for the assumed role session. Environment varaibles will be evaluated.
+    type: string
+    default: ${CIRCLE_JOB}
+  session-duration:
+    description: The duration of the session in seconds
+    type: string
+    default: "3600"
 steps:
-  - aws-cli/setup:
-      aws-access-key-id: << parameters.aws-access-key-id >>
-      aws-secret-access-key: << parameters.aws-secret-access-key >>
-      aws-region: << parameters.aws-region >>
+  - when:
+      condition: <<parameters.role-arn>>
+      steps:
+        - aws-cli/setup:
+            role-arn: <<parameters.role-arn>>
+            profile-name: <<parameters.profile-name>>
+            session-duration: <<parameters.session-duration>>
+            aws-region: <<parameters.aws-region>>
+            role-session-name: <<parameters.role-session-name>>
+  - unless:
+      condition: <<parameters.role-arn>>
+      steps:
+        - aws-cli/setup:
+            aws-access-key-id: << parameters.aws-access-key-id >>
+            aws-secret-access-key: << parameters.aws-secret-access-key >>
+            aws-region: << parameters.aws-region >>
+            profile-name: << parameters.profile-name >>
   - run:
       name: S3 Copy << parameters.from >> -> << parameters.to >>
       environment:

--- a/src/commands/sync.yml
+++ b/src/commands/sync.yml
@@ -7,7 +7,6 @@ parameters:
   to:
     type: string
     description: A URI to an S3 bucket, i.e. 's3://the-name-my-bucket'
-
   arguments:
     type: string
     default: ""
@@ -28,11 +27,42 @@ parameters:
     type: env_var_name
     description: aws region override
     default: AWS_REGION
+  profile-name:
+    description: AWS profile name to be configured.
+    type: string
+    default: ''
+  role-arn:
+    description: |
+      The Amazon Resource Name (ARN) of the role that the caller is assuming.
+      Role ARN must be configured for web identity.
+    type: string
+    default: ""
+  role-session-name:
+    description: An identifier for the assumed role session. Environment varaibles will be evaluated.
+    type: string
+    default: ${CIRCLE_JOB}
+  session-duration:
+    description: The duration of the session in seconds
+    type: string
+    default: "3600"
 steps:
-  - aws-cli/setup:
-      aws-access-key-id: << parameters.aws-access-key-id >>
-      aws-secret-access-key: << parameters.aws-secret-access-key >>
-      aws-region: << parameters.aws-region >>
+  - when:
+      condition: <<parameters.role-arn>>
+      steps:
+        - aws-cli/setup:
+            role-arn: <<parameters.role-arn>>
+            profile-name: <<parameters.profile-name>>
+            session-duration: <<parameters.session-duration>>
+            aws-region: <<parameters.aws-region>>
+            role-session-name: <<parameters.role-session-name>>
+  - unless:
+      condition: <<parameters.role-arn>>
+      steps:
+        - aws-cli/setup:
+            aws-access-key-id: << parameters.aws-access-key-id >>
+            aws-secret-access-key: << parameters.aws-secret-access-key >>
+            aws-region: << parameters.aws-region >>
+            profile-name: << parameters.profile-name >>
   - deploy:
       name: S3 Sync
       environment:


### PR DESCRIPTION
This `PR` makes use of CircleCI's `OIDC Token` to generate temporary `AWS` keys, enabling users to run `s3` commands   securely without having to store static keys as environment variables. 

To generate temporary tokens, provide the job with a valid context, `role-arn` and `role-session-name`. 