### PR TITLE
feat: pass through when parameter

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -30,7 +30,6 @@ jobs:
           from: bucket
           to: "s3://orb-testing-1/s3-orb"
           role-arn: arn:aws:iam::122211685980:role/CPE_S3_OIDC_TEST
-          when: "on_fail"
       - aws-s3/copy:
           from: bucket/build_asset.txt
           to: "s3://orb-testing-1"

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -30,6 +30,7 @@ jobs:
           from: bucket
           to: "s3://orb-testing-1/s3-orb"
           role-arn: arn:aws:iam::122211685980:role/CPE_S3_OIDC_TEST
+          when: "on_fail"
       - aws-s3/copy:
           from: bucket/build_asset.txt
           to: "s3://orb-testing-1"

--- a/src/commands/copy.yml
+++ b/src/commands/copy.yml
@@ -41,6 +41,12 @@ parameters:
     description: The duration of the session in seconds
     type: string
     default: "3600"
+  when:
+    description: |
+      Add the when attribute to a job step to override its default behaviour
+      and selectively run or skip steps depending on the status of the job.
+    type: string
+    default: "on_success"
 steps:
   - when:
       condition: <<parameters.role-arn>>
@@ -61,6 +67,7 @@ steps:
             profile-name: << parameters.profile-name >>
   - run:
       name: S3 Copy << parameters.from >> -> << parameters.to >>
+      when: <<parameters.when>>
       environment:
         PARAM_AWS_S3_FROM: <<parameters.from>>
         PARAM_AWS_S3_TO: <<parameters.to>>

--- a/src/commands/copy.yml
+++ b/src/commands/copy.yml
@@ -45,7 +45,8 @@ parameters:
     description: |
       Add the when attribute to a job step to override its default behaviour
       and selectively run or skip steps depending on the status of the job.
-    type: string
+    type: enum
+    enum: ["on_success", "on_fail", "always"]
     default: "on_success"
 steps:
   - when:

--- a/src/commands/sync.yml
+++ b/src/commands/sync.yml
@@ -49,7 +49,8 @@ parameters:
     description: |
       Add the when attribute to a job step to override its default behaviour
       and selectively run or skip steps depending on the status of the job.
-    type: string
+    type: enum
+    enum: ["on_success", "on_fail", "always"]
     default: "on_success"
 steps:
   - when:

--- a/src/commands/sync.yml
+++ b/src/commands/sync.yml
@@ -45,6 +45,12 @@ parameters:
     description: The duration of the session in seconds
     type: string
     default: "3600"
+  when:
+    description: |
+      Add the when attribute to a job step to override its default behaviour
+      and selectively run or skip steps depending on the status of the job.
+    type: string
+    default: "on_success"
 steps:
   - when:
       condition: <<parameters.role-arn>>
@@ -65,6 +71,7 @@ steps:
             profile-name: << parameters.profile-name >>
   - deploy:
       name: S3 Sync
+      when: <<parameters.when>>
       environment:
         PARAM_AWS_S3_FROM: <<parameters.from>>
         PARAM_AWS_S3_TO: <<parameters.to>>


### PR DESCRIPTION
This `PR` enables the use of `when` parameter with the `aws-s3` commands. Users are now able to specify when the command runs. 