### PR TITLE
feat: skip install-aws-cli parameter

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -19,7 +19,7 @@ jobs:
       - aws-s3/copy:
           from: bucket/build_asset.txt
           to: "s3://orb-testing-1"
-          role-arn: arn:aws:iam::122211685980:role/CPE_S3_OIDC_TEST          
+          role-arn: arn:aws:iam::122211685980:role/CPE_S3_OIDC_TEST      
   integration-test-2:
     docker:
       - image: cimg/base:stable
@@ -34,6 +34,7 @@ jobs:
           from: bucket/build_asset.txt
           to: "s3://orb-testing-1"
           role-arn: arn:aws:iam::122211685980:role/CPE_S3_OIDC_TEST
+
 workflows:
   test-deploy:
     jobs:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -19,7 +19,8 @@ jobs:
       - aws-s3/copy:
           from: bucket/build_asset.txt
           to: "s3://orb-testing-1"
-          role-arn: arn:aws:iam::122211685980:role/CPE_S3_OIDC_TEST      
+          role-arn: arn:aws:iam::122211685980:role/CPE_S3_OIDC_TEST
+          install-aws-cli: false
   integration-test-2:
     docker:
       - image: cimg/base:stable
@@ -34,6 +35,7 @@ jobs:
           from: bucket/build_asset.txt
           to: "s3://orb-testing-1"
           role-arn: arn:aws:iam::122211685980:role/CPE_S3_OIDC_TEST
+          install-aws-cli: false
 
 workflows:
   test-deploy:

--- a/src/commands/copy.yml
+++ b/src/commands/copy.yml
@@ -41,6 +41,10 @@ parameters:
     description: The duration of the session in seconds
     type: string
     default: "3600"
+  install-aws-cli:
+    description: The aws-cli is installed when this parameter is set to true. Set to false to skip installation
+    type: boolean
+    default: true
   when:
     description: |
       Add the when attribute to a job step to override its default behaviour
@@ -50,22 +54,25 @@ parameters:
     default: "on_success"
 steps:
   - when:
-      condition: <<parameters.role-arn>>
+      condition: <<parameters.install-aws-cli>>
       steps:
-        - aws-cli/setup:
-            role-arn: <<parameters.role-arn>>
-            profile-name: <<parameters.profile-name>>
-            session-duration: <<parameters.session-duration>>
-            aws-region: <<parameters.aws-region>>
-            role-session-name: <<parameters.role-session-name>>
-  - unless:
-      condition: <<parameters.role-arn>>
-      steps:
-        - aws-cli/setup:
-            aws-access-key-id: << parameters.aws-access-key-id >>
-            aws-secret-access-key: << parameters.aws-secret-access-key >>
-            aws-region: << parameters.aws-region >>
-            profile-name: << parameters.profile-name >>
+        - when:
+            condition: <<parameters.role-arn>>
+            steps:
+              - aws-cli/setup:
+                  role-arn: <<parameters.role-arn>>
+                  profile-name: <<parameters.profile-name>>
+                  session-duration: <<parameters.session-duration>>
+                  aws-region: <<parameters.aws-region>>
+                  role-session-name: <<parameters.role-session-name>>
+        - unless:
+            condition: <<parameters.role-arn>>
+            steps:
+              - aws-cli/setup:
+                  aws-access-key-id: << parameters.aws-access-key-id >>
+                  aws-secret-access-key: << parameters.aws-secret-access-key >>
+                  aws-region: << parameters.aws-region >>
+                  profile-name: << parameters.profile-name >>
   - run:
       name: S3 Copy << parameters.from >> -> << parameters.to >>
       when: <<parameters.when>>

--- a/src/commands/sync.yml
+++ b/src/commands/sync.yml
@@ -45,6 +45,10 @@ parameters:
     description: The duration of the session in seconds
     type: string
     default: "3600"
+  install-aws-cli:
+    description: The aws-cli is installed when this parameter is set to true. Set to false to skip installation
+    type: boolean
+    default: true    
   when:
     description: |
       Add the when attribute to a job step to override its default behaviour
@@ -54,22 +58,25 @@ parameters:
     default: "on_success"
 steps:
   - when:
-      condition: <<parameters.role-arn>>
+      condition: <<parameters.install-aws-cli>>
       steps:
-        - aws-cli/setup:
-            role-arn: <<parameters.role-arn>>
-            profile-name: <<parameters.profile-name>>
-            session-duration: <<parameters.session-duration>>
-            aws-region: <<parameters.aws-region>>
-            role-session-name: <<parameters.role-session-name>>
-  - unless:
-      condition: <<parameters.role-arn>>
-      steps:
-        - aws-cli/setup:
-            aws-access-key-id: << parameters.aws-access-key-id >>
-            aws-secret-access-key: << parameters.aws-secret-access-key >>
-            aws-region: << parameters.aws-region >>
-            profile-name: << parameters.profile-name >>
+        - when:
+            condition: <<parameters.role-arn>>
+            steps:
+              - aws-cli/setup:
+                  role-arn: <<parameters.role-arn>>
+                  profile-name: <<parameters.profile-name>>
+                  session-duration: <<parameters.session-duration>>
+                  aws-region: <<parameters.aws-region>>
+                  role-session-name: <<parameters.role-session-name>>
+        - unless:
+            condition: <<parameters.role-arn>>
+            steps:
+              - aws-cli/setup:
+                  aws-access-key-id: << parameters.aws-access-key-id >>
+                  aws-secret-access-key: << parameters.aws-secret-access-key >>
+                  aws-region: << parameters.aws-region >>
+                  profile-name: << parameters.profile-name >>
   - deploy:
       name: S3 Sync
       when: <<parameters.when>>

--- a/src/commands/sync.yml
+++ b/src/commands/sync.yml
@@ -48,7 +48,7 @@ parameters:
   install-aws-cli:
     description: The aws-cli is installed when this parameter is set to true. Set to false to skip installation
     type: boolean
-    default: true    
+    default: true
   when:
     description: |
       Add the when attribute to a job step to override its default behaviour


### PR DESCRIPTION
This `PR` adds the `install-aws-cli` parameter. By default, it's set to `true` but setting it to `false` enables users to skip installation.