### PR TITLE
feat: implement profile-name parameter

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -37,6 +37,7 @@ jobs:
       - aws-s3/copy:
           from: bucket/build_asset.txt
           to: "s3://orb-testing-1"
+          profile-name: "OIDC-User"
           install-aws-cli: false
 workflows:
   test-deploy:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -33,10 +33,10 @@ jobs:
           from: bucket
           to: "s3://orb-testing-1/s3-orb"
           role-arn: arn:aws:iam::122211685980:role/CPE_S3_OIDC_TEST
+          profile-name: "OIDC-User"
       - aws-s3/copy:
           from: bucket/build_asset.txt
           to: "s3://orb-testing-1"
-          role-arn: arn:aws:iam::122211685980:role/CPE_S3_OIDC_TEST
           install-aws-cli: false
 workflows:
   test-deploy:

--- a/src/commands/copy.yml
+++ b/src/commands/copy.yml
@@ -80,4 +80,5 @@ steps:
         PARAM_AWS_S3_FROM: <<parameters.from>>
         PARAM_AWS_S3_TO: <<parameters.to>>
         PARAM_AWS_S3_ARGUMENTS: <<parameters.arguments>>
+        PARAM_AWS_S3_PROFILE_NAME: <<parameters.profile-name>>
       command: <<include(scripts/copy.sh)>>

--- a/src/commands/sync.yml
+++ b/src/commands/sync.yml
@@ -84,4 +84,5 @@ steps:
         PARAM_AWS_S3_FROM: <<parameters.from>>
         PARAM_AWS_S3_TO: <<parameters.to>>
         PARAM_AWS_S3_ARGUMENTS: <<parameters.arguments>>
+        PARAM_AWS_S3_PROFILE_NAME: <<parameters.profile-name>>
       command: <<include(scripts/sync.sh)>>

--- a/src/scripts/copy.sh
+++ b/src/scripts/copy.sh
@@ -7,4 +7,8 @@ if [ -n "${PARAM_AWS_S3_ARGUMENTS}" ]; then
     set -- "$@" "${PARAM_AWS_S3_ARGUMENTS}"
 fi
 
+if [ -n "${PARAM_AWS_S3_PROFILE_NAME}" ]; then
+    set -- "$@" --profile "${PARAM_AWS_S3_PROFILE_NAME}"
+fi    
+
 aws s3 cp "${PARAM_AWS_S3_FROM}" "${PARAM_AWS_S3_TO}" "$@"

--- a/src/scripts/sync.sh
+++ b/src/scripts/sync.sh
@@ -7,4 +7,8 @@ if [ -n "${PARAM_AWS_S3_ARGUMENTS}" ]; then
     set -- "$@" "${PARAM_AWS_S3_ARGUMENTS}"
 fi
 
+if [ -n "${PARAM_AWS_S3_PROFILE_NAME}" ]; then
+    set -- "$@" --profile "${PARAM_AWS_S3_PROFILE_NAME}"
+fi
+
 aws s3 sync "${PARAM_AWS_S3_FROM}" "${PARAM_AWS_S3_TO}" "$@"


### PR DESCRIPTION
This `PR` adds the `--profile` flag to the `AWS s3` commands, enabling users to execute commands with different configured profiles. 