### PR TITLE
chore: update aws-cli version

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -9,4 +9,4 @@ display:
   source_url: https://github.com/CircleCI-Public/aws-s3-orb
 
 orbs:
-  aws-cli: circleci/aws-cli@3.1
+  aws-cli: circleci/aws-cli@3.1.4


### PR DESCRIPTION
This `PR` updates the `aws-cli` version to include a patch fix that's causing installation on `Alpine` linux to fail.