### PR TITLE
fix/unknown options issue

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -43,6 +43,7 @@ jobs:
           from: bucket/build_asset.txt
           to: "s3://orb-testing-1"
           profile-name: "OIDC-User"
+          arguments: --cache-control "public, max-age=15" --acl bucket-owner-full-control
 workflows:
   test-deploy:
     jobs:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -38,7 +38,7 @@ jobs:
           from: bucket
           to: "s3://orb-testing-1/s3-orb"
           profile-name: "OIDC-User"
-          arguments: --acl public-read --cache-control "max-age=86400"          
+          arguments: --acl public-read --cache-control max-age=86400
       - aws-s3/copy:
           from: bucket/build_asset.txt
           to: "s3://orb-testing-1"

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -38,6 +38,7 @@ jobs:
           from: bucket
           to: "s3://orb-testing-1/s3-orb"
           profile-name: "OIDC-User"
+          arguments: --acl public-read --cache-control "max-age=86400"          
       - aws-s3/copy:
           from: bucket/build_asset.txt
           to: "s3://orb-testing-1"

--- a/src/commands/copy.yml
+++ b/src/commands/copy.yml
@@ -8,7 +8,10 @@ parameters:
     type: string
     description: A local target or s3 destination
   arguments:
-    description: If you wish to pass any additional arguments to the aws copy command (i.e. -sse)
+    description: > 
+      If you wish to pass any additional arguments to the aws copy command (i.e. -sse)
+      Note: Please pass all values to this to this parameter in a single line without quotations so the
+      Bash shell can correctly interpret the entire command.
     default: ''
     type: string
   profile-name:

--- a/src/commands/copy.yml
+++ b/src/commands/copy.yml
@@ -8,7 +8,7 @@ parameters:
     type: string
     description: A local target or s3 destination
   arguments:
-    description: > 
+    description: >
       If you wish to pass any additional arguments to the aws copy command (i.e. -sse)
       Note: Please pass all values to this to this parameter in a single line without quotations so the
       Bash shell can correctly interpret the entire command.

--- a/src/commands/sync.yml
+++ b/src/commands/sync.yml
@@ -12,8 +12,8 @@ parameters:
     default: ""
     description: >
       Optional additional arguments to pass to the `aws sync` command
-      (e.g., `--acl public-read`). Note: if passing a multi-line value
-      to this parameter, include `\` characters after each line, so the
+      (e.g., `--acl public-read`). Note: Please pass all values to this
+      to this parameter in a single line without quotations so the
       Bash shell can correctly interpret the entire command.
   profile-name:
     description: AWS profile name to be configured.

--- a/src/jobs/copy.yml
+++ b/src/jobs/copy.yml
@@ -8,7 +8,10 @@ parameters:
     type: string
     description: A local target or s3 destination
   arguments:
-    description: If you wish to pass any additional arguments to the aws copy command (i.e. -sse)
+    description: > 
+      If you wish to pass any additional arguments to the aws copy command (i.e. -sse)
+      Note: Please pass all values to this to this parameter in a single line without quotations so the
+      Bash shell can correctly interpret the entire command.
     default: ''
     type: string
   profile-name:

--- a/src/jobs/copy.yml
+++ b/src/jobs/copy.yml
@@ -8,7 +8,7 @@ parameters:
     type: string
     description: A local target or s3 destination
   arguments:
-    description: > 
+    description: >
       If you wish to pass any additional arguments to the aws copy command (i.e. -sse)
       Note: Please pass all values to this to this parameter in a single line without quotations so the
       Bash shell can correctly interpret the entire command.

--- a/src/jobs/sync.yml
+++ b/src/jobs/sync.yml
@@ -8,7 +8,11 @@ parameters:
     type: string
     description: A local target or s3 destination
   arguments:
-    description: If you wish to pass any additional arguments to the aws copy command (i.e. -sse)
+    description: >
+      Optional additional arguments to pass to the `aws sync` command
+      (e.g., `--acl public-read`). Note: Please pass all values to this
+      to this parameter in a single line without quotations so the
+      Bash shell can correctly interpret the entire command.
     default: ''
     type: string
   profile-name:

--- a/src/scripts/copy.sh
+++ b/src/scripts/copy.sh
@@ -3,8 +3,9 @@ PARAM_AWS_S3_FROM=$(eval echo "${PARAM_AWS_S3_FROM}")
 PARAM_AWS_S3_TO=$(eval echo "${PARAM_AWS_S3_TO}")
 PARAM_AWS_S3_ARGUMENTS=$(eval echo "${PARAM_AWS_S3_ARGUMENTS}")
 
+# shellcheck disable=SC2086
 if [ -n "${PARAM_AWS_S3_ARGUMENTS}" ]; then
-    set -- "$@" "${PARAM_AWS_S3_ARGUMENTS}"
+    set -- "$@" ${PARAM_AWS_S3_ARGUMENTS}
 fi
 
 if [ -n "${PARAM_AWS_S3_PROFILE_NAME}" ]; then

--- a/src/scripts/sync.sh
+++ b/src/scripts/sync.sh
@@ -3,8 +3,9 @@ PARAM_AWS_S3_FROM=$(eval echo "${PARAM_AWS_S3_FROM}")
 PARAM_AWS_S3_TO=$(eval echo "${PARAM_AWS_S3_TO}")
 PARAM_AWS_S3_ARGUMENTS=$(eval echo "${PARAM_AWS_S3_ARGUMENTS}")
 
+# shellcheck disable=SC2086
 if [ -n "${PARAM_AWS_S3_ARGUMENTS}" ]; then
-    set -- "$@" "${PARAM_AWS_S3_ARGUMENTS}"
+    set -- "$@" ${PARAM_AWS_S3_ARGUMENTS}
 fi
 
 if [ -n "${PARAM_AWS_S3_PROFILE_NAME}" ]; then


### PR DESCRIPTION
The current version of this orb fails when providing more than one argument in the `arguments` parameter. With the way the orb is using `eval`, it injects single quotes around the `arguments`, causing the `cli` to throw an error: 

```
aws s3 sync bucket s3://orb-testing-1/s3-orb **'--acl public-read --cache-control max-age=86400'** --profile OIDC-User
Unknown options: --acl public-read --cache-control max-age=86400
```

This `PR` resolves this issue by removing the double quotes around the `${PARAM_AWS_S3_ARGUMENTS}` variable in the bash script. 

**However, users must not use white spacing or quotations when providing arguments to the `arguments` parameter as it will cause issues with the expansion**