### PR TITLE
refactor!: orb tools 12 migration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 setup: true
 orbs:
-  orb-tools: circleci/orb-tools@11.6
+  orb-tools: circleci/orb-tools@12.0
   shellcheck: circleci/shellcheck@3.1
 
 filters: &filters
@@ -19,17 +19,10 @@ workflows:
           filters: *filters
       - shellcheck/check:
           filters: *filters
-      - orb-tools/publish:
-          orb-name: circleci/aws-s3
-          vcs-type: << pipeline.project.type >>
-          requires:
-            [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
-          # Use a context to hold your publishing token.
-          context: orb-publisher
-          filters: *filters
       # Triggers the next workflow in the Orb Development Kit.
       - orb-tools/continue:
-          pipeline-number: << pipeline.number >>
-          vcs-type: << pipeline.project.type >>
-          requires: [orb-tools/publish]
+          orb_name: aws-s3
+          pipeline_number: << pipeline.number >>
+          vcs_type: << pipeline.project.type >>
+          requires: [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
           filters: *filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,14 +1,19 @@
 version: 2.1
 orbs:
-  aws-s3: circleci/aws-s3@dev:<<pipeline.git.revision>>
-  orb-tools: circleci/orb-tools@11.6
-  aws-cli: circleci/aws-cli@3.1
+  orb-tools: circleci/orb-tools@12.0
+  aws-cli: circleci/aws-cli@4.0
+  aws-s3: {}
 filters: &filters
   tags:
     only: /.*/
+release-filters: &release-filters
+  branches:
+    ignore: /.*/
+  tags:
+    only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
 executors:
   alpine:
-    docker: 
+    docker:
       - image: alpine:latest
   docker-base:
     docker:
@@ -30,18 +35,18 @@ jobs:
     steps:
       - checkout
       - run: mkdir bucket && echo "lorem ipsum" > bucket/build_asset.txt
-      - aws-cli/setup:    
-          role-arn: arn:aws:iam::122211685980:role/CPE_S3_OIDC_TEST
-          profile-name: "OIDC-User"
+      - aws-cli/setup:
+          role_arn: arn:aws:iam::122211685980:role/CPE_S3_OIDC_TEST
+          profile_name: "OIDC-User"
           role-session-name: "OIDC-test-session"
       - aws-s3/sync:
           from: "bucket"
           to: "s3://orb-testing-1/s3-orb"
-          profile-name: "OIDC-User"
+          profile_name: "OIDC-User"
       - aws-s3/copy:
           from: "bucket/build_asset.txt"
           to: "s3://orb-testing-1"
-          profile-name: "OIDC-User"
+          profile_name: "OIDC-User"
 workflows:
   test-deploy:
     jobs:
@@ -52,50 +57,42 @@ workflows:
           filters: *filters
           matrix:
             parameters:
-              executor: [ "alpine", "docker-base", "windows", "macos" ]
+              executor: ["alpine", "docker-base", "windows", "macos"]
       - aws-s3/sync:
           pre-steps:
             - run: cd ~/ && mkdir bucket && echo "lorem ipsum" > bucket/build_asset.txt
           auth:
             - aws-cli/setup:
-                role-arn: arn:aws:iam::122211685980:role/CPE_S3_OIDC_TEST
+                role_arn: arn:aws:iam::122211685980:role/CPE_S3_OIDC_TEST
                 role-session-name: "Test-session"
-                profile-name: "OIDC-User"
+                profile_name: "OIDC-User"
           from: "$HOME/bucket"
           to: "s3://orb-testing-1/s3-orb"
-          profile-name: "OIDC-User"
+          profile_name: "OIDC-User"
           context: [CPE-OIDC]
+          filters: *filters
       - aws-s3/copy:
           pre-steps:
             - run: cd ~/ && mkdir bucket && echo "lorem ipsum" > bucket/build_asset.txt
           auth:
             - aws-cli/setup:
-                role-arn: arn:aws:iam::122211685980:role/CPE_S3_OIDC_TEST
+                role_arn: arn:aws:iam::122211685980:role/CPE_S3_OIDC_TEST
                 role-session-name: "Test-session"
-                profile-name: "OIDC-User"
+                profile_name: "OIDC-User"
           from: "$HOME/bucket/build_asset.txt"
           to: "s3://orb-testing-1"
-          profile-name: "OIDC-User"
+          profile_name: "OIDC-User"
           context: [CPE-OIDC]
+          filters: *filters
           requires:
             - aws-s3/sync
       - orb-tools/pack:
-          filters: *filters
+          filters: *release-filters
       - orb-tools/publish:
           orb-name: circleci/aws-s3
-          vcs-type: << pipeline.project.type >>
-          pub-type: production
-          requires:
-            - orb-tools/pack
-            - integration-test-alpine
-            - integration-test-docker-base
-            - integration-test-windows
-            - integration-test-macos
-            - aws-s3/copy
-            - aws-s3/sync
+          vcs_type: << pipeline.project.type >>
+          pub_type: production
+          enable_pr_comment: true
+          requires: [orb-tools/pack, integration-test-alpine, integration-test-docker-base, integration-test-windows, integration-test-macos, aws-s3/copy, aws-s3/sync]
           context: orb-publisher
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+          filters: *release-filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -38,7 +38,7 @@ jobs:
       - aws-cli/setup:
           role_arn: arn:aws:iam::122211685980:role/CPE_S3_OIDC_TEST
           profile_name: "OIDC-User"
-          role-session-name: "OIDC-test-session"
+          role_session_name: "OIDC-test-session"
       - aws-s3/sync:
           from: "bucket"
           to: "s3://orb-testing-1/s3-orb"
@@ -64,7 +64,7 @@ workflows:
           auth:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_S3_OIDC_TEST
-                role-session-name: "Test-session"
+                role_session_name: "Test-session"
                 profile_name: "OIDC-User"
           from: "$HOME/bucket"
           to: "s3://orb-testing-1/s3-orb"
@@ -77,7 +77,7 @@ workflows:
           auth:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_S3_OIDC_TEST
-                role-session-name: "Test-session"
+                role_session_name: "Test-session"
                 profile_name: "OIDC-User"
           from: "$HOME/bucket/build_asset.txt"
           to: "s3://orb-testing-1"

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -89,7 +89,7 @@ workflows:
       - orb-tools/pack:
           filters: *release-filters
       - orb-tools/publish:
-          orb-name: circleci/aws-s3
+          orb_name: circleci/aws-s3
           vcs_type: << pipeline.project.type >>
           pub_type: production
           enable_pr_comment: true

--- a/src/commands/copy.yml
+++ b/src/commands/copy.yml
@@ -11,11 +11,11 @@ parameters:
     description: If you wish to pass any additional arguments to the aws copy command (i.e. -sse)
     default: ''
     type: string
-  profile-name:
+  profile_name:
     description: AWS profile name to be configured.
     type: string
     default: "default"
-  role-arn:
+  role_arn:
     description: |
       The Amazon Resource Name (ARN) of the role that the caller is assuming.
       Role ARN must be configured for web identity.
@@ -23,7 +23,7 @@ parameters:
     default: ""
   when:
     description: |
-      Add the when attribute to a job step to override its default behaviour
+      Add the when attribute to a job step to override its default behavior
       and selectively run or skip steps depending on the status of the job.
     type: enum
     enum: ["on_success", "on_fail", "always"]
@@ -36,5 +36,5 @@ steps:
         ORB_EVAL_FROM: <<parameters.from>>
         ORB_EVAL_TO: <<parameters.to>>
         ORB_EVAL_ARGUMENTS: <<parameters.arguments>>
-        ORB_EVAL_PROFILE_NAME: <<parameters.profile-name>>
+        ORB_EVAL_PROFILE_NAME: <<parameters.profile_name>>
       command: <<include(scripts/copy.sh)>>

--- a/src/commands/sync.yml
+++ b/src/commands/sync.yml
@@ -15,13 +15,13 @@ parameters:
       (e.g., `--acl public-read`). Note: if passing a multi-line value
       to this parameter, include `\` characters after each line, so the
       Bash shell can correctly interpret the entire command.
-  profile-name:
+  profile_name:
     description: AWS profile name to be configured.
     type: string
     default: "default"
   when:
     description: |
-      Add the when attribute to a job step to override its default behaviour
+      Add the when attribute to a job step to override its default behavior
       and selectively run or skip steps depending on the status of the job.
     type: enum
     enum: ["on_success", "on_fail", "always"]
@@ -34,5 +34,5 @@ steps:
         ORB_EVAL_FROM: <<parameters.from>>
         ORB_EVAL_TO: <<parameters.to>>
         ORB_EVAL_ARGUMENTS: <<parameters.arguments>>
-        ORB_EVAL_PROFILE_NAME: <<parameters.profile-name>>
+        ORB_EVAL_PROFILE_NAME: <<parameters.profile_name>>
       command: <<include(scripts/sync.sh)>>

--- a/src/examples/authentication_with_jobs.yml
+++ b/src/examples/authentication_with_jobs.yml
@@ -1,7 +1,7 @@
 description: >
   The S3 orb allows you to "sync" directories or "copy" files to an S3 bucket. The example below demonstrates how to use
   the "sync" and "copy" jobs. It also demonstrates the use of OIDC authentication in a job with the required "auth" parameter.
-  The aws-cli orb must be imported and the aws-cli/setup command must be used with a valid AWS role-arn.
+  The aws-cli orb must be imported and the aws-cli/setup command must be used with a valid AWS role_arn.
 usage:
   version: 2.1
   orbs:
@@ -15,16 +15,16 @@ usage:
             auth:
               # Add authentication step with OIDC using aws-cli/setup command
               - aws-cli/setup:
-                  role-arn: arn:aws:iam::123456789012/role/VALID-S3-ROLE
-                  profile-name: "OIDC-User"
+                  role_arn: arn:aws:iam::123456789012/role/VALID-S3-ROLE
+                  profile_name: "OIDC-User"
             from: PATH/TO/FILE
             to: "s3://my-s3-bucket-name"
             # Profile name must be the same as authentication step if specified
-            profile-name: "OIDC-User"
+            profile_name: "OIDC-User"
         - aws-s3/sync:
             auth:
               # Add authentication step with OIDC using aws-cli/setup command
               - aws-cli/setup:
-                  role-arn: arn:aws:iam::123456789012/role/VALID-S3-ROLE
+                  role_arn: arn:aws:iam::123456789012/role/VALID-S3-ROLE
             from: bucket
             to: "s3://my-s3-bucket-name/prefix"

--- a/src/examples/sync_and_copy_with_oidc.yml
+++ b/src/examples/sync_and_copy_with_oidc.yml
@@ -2,7 +2,7 @@ description: >
   The S3 orb allows you to "sync" directories or "copy" files to an S3 bucket.
   The example below shows a typical CircleCI job where a file "bucket/build_asset.txt" is created,
   followed by how we can both sync, and/or copy the file. It also demonstrates the use of OIDC authentication by importing
-  the aws-cli orb and providing the aws-cli/setup command with a valid AWS role-arn and profile name.
+  the aws-cli orb and providing the aws-cli/setup command with a valid AWS role_arn and profile name.
   If a profile name is specified with authentication, it must be specified in the copy and sync commands.
 usage:
   version: 2.1
@@ -19,11 +19,11 @@ usage:
         - run: mkdir bucket && echo "lorem ipsum" > bucket/build_asset.txt
         # Add authentication step with OIDC using aws-cli/setup command
         - aws-cli/setup:
-            role-arn: arn:aws:iam::123456789012/role/VALID-S3-ROLE
-            profile-name: "OIDC-User"
+            role_arn: arn:aws:iam::123456789012/role/VALID-S3-ROLE
+            profile_name: "OIDC-User"
         - aws-s3/sync:
             # Profile name must be the same as authentication step
-            profile-name: "OIDC-User"
+            profile_name: "OIDC-User"
             from: bucket
             to: "s3://my-s3-bucket-name/prefix"
             arguments: |
@@ -31,7 +31,7 @@ usage:
               --cache-control "max-age=86400"
         - aws-s3/copy:
             # Profile name must be the same as authentication step
-            profile-name: "OIDC-User"
+            profile_name: "OIDC-User"
             from: bucket/build_asset.txt
             to: "s3://my-s3-bucket-name"
             arguments: --dryrun

--- a/src/jobs/copy.yml
+++ b/src/jobs/copy.yml
@@ -11,7 +11,7 @@ parameters:
     description: If you wish to pass any additional arguments to the aws copy command (i.e. -sse)
     default: ''
     type: string
-  profile-name:
+  profile_name:
     description: AWS profile name to be configured.
     type: string
     default: "default"
@@ -28,7 +28,7 @@ parameters:
     enum: ["on_success", "on_fail", "always"]
     default: "on_success"
 docker:
-  - image: cimg/base:current
+  - image: cimg/aws:2023.05
 steps:
   - checkout
   - steps: <<parameters.auth>>
@@ -37,4 +37,4 @@ steps:
       from: <<parameters.from>>
       to: <<parameters.to>>
       arguments: <<parameters.arguments>>
-      profile-name: <<parameters.profile-name>>
+      profile_name: <<parameters.profile_name>>

--- a/src/jobs/sync.yml
+++ b/src/jobs/sync.yml
@@ -11,7 +11,7 @@ parameters:
     description: If you wish to pass any additional arguments to the aws copy command (i.e. -sse)
     default: ''
     type: string
-  profile-name:
+  profile_name:
     description: AWS profile name to be configured.
     type: string
     default: "default"
@@ -28,7 +28,7 @@ parameters:
     enum: ["on_success", "on_fail", "always"]
     default: "on_success"
 docker:
-  - image: cimg/base:current
+  - image: cimg/aws:2023.05
 steps:
   - checkout
   - steps: <<parameters.auth>>
@@ -37,4 +37,4 @@ steps:
       from: <<parameters.from>>
       to: <<parameters.to>>
       arguments: <<parameters.arguments>>
-      profile-name: <<parameters.profile-name>>
+      profile_name: <<parameters.profile_name>>


### PR DESCRIPTION
## Description

This major release updates the `AWS S3` Orb to the new major version of Orb Tools. As it contains breaking changes, several modifications were unnecessary to move from v11 to [v12](https://circleci.com/developer/orbs/orb/circleci/orb-tools). 

## Changes

1. All parameters and commands containing dashes have been converted to the new snake case standard (replace `-` with `_`).
2. The comprehensive list of changes can be found below.

### Changes in `.circleci/config.yml`:

1. Update the orb-tools version from 11.6 to 12.0.
1. Move the job requirement list from `orb-tools/publish` to `orb-tools/continue`.
1. Remove the `orb-tools/publish` job since development versions are no longer necessary.
1. Add the new `orb_name` parameter in `orb-tools/continue`.
1. Rename the `orb-tools/continue` job parameters to comply with the new snake case standard.
   - `orb_name`, `pipeline_number` and `vcs_type`.

### Changes in `.circleci/test-deploy.yml`:

1. Update the orb-tools version from `11.6` to `12.0`.
1. Remove the `aws-cli: circleci/aws-cli@dev:<<pipeline.git.revision>>` line, and replace it with `aws-cli: {}`.
1. Remove the `orb-tools/lint`, `orb-tools/pack`, and `orb-tools/review` jobs. ⚠️ 
1. Rename the `orb-tools/publish` job parameters to comply with the new snake case standard.
   - `orb_name`, `vcs_type`, `pub_type`, `enable_pr_comment` and `github_token`.
1. Change the `orb-tools/pack` filter to trigger only on tagged releases.