### PR TITLE
Set profile as an optional parameter in the cli

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -13,7 +13,7 @@ release-filters: &release-filters
     only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
 executors:
   alpine:
-    shell: bash -eox pipefail
+    shell: sh -eox pipefail
     docker:
       - image: alpine:latest
   docker-base:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -51,10 +51,11 @@ workflows:
           context: [CPE-OIDC]
           filters: *filters
           matrix:
+            alias: integration-test
             parameters:
               executor: ["alpine", "docker-base"]
       - aws-s3/sync:
-          name: Sync simple
+          name: sync-simple
           pre-steps:
             - run: cd ~/ && mkdir bucket && echo "lorem ipsum" > bucket/build_asset.txt
           auth:
@@ -68,7 +69,7 @@ workflows:
           context: [CPE-OIDC]
           filters: *filters
       - aws-s3/sync:
-          name: Sync with args
+          name: sync-with-args
           pre-steps:
             - run: cd ~/ && mkdir bucket && echo "lorem ipsum" > bucket/build_asset.txt
           auth:
@@ -104,6 +105,6 @@ workflows:
           vcs_type: << pipeline.project.type >>
           pub_type: production
           enable_pr_comment: true
-          requires: [orb-tools/pack, integration-test-alpine, integration-test-docker-base, aws-s3/copy, aws-s3/sync]
+          requires: [orb-tools/pack, integration-test, aws-s3/copy, sync-simple, sync-with-args]
           context: orb-publisher
           filters: *release-filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -13,6 +13,7 @@ release-filters: &release-filters
     only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
 executors:
   alpine:
+    shell: bash -eox pipefail
     docker:
       - image: alpine:latest
   docker-base:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -54,6 +54,7 @@ workflows:
             parameters:
               executor: ["alpine", "docker-base"]
       - aws-s3/sync:
+          name: Sync simple
           pre-steps:
             - run: cd ~/ && mkdir bucket && echo "lorem ipsum" > bucket/build_asset.txt
           auth:
@@ -64,6 +65,21 @@ workflows:
           from: "$HOME/bucket"
           to: "s3://orb-testing-1/s3-orb"
           profile_name: "OIDC-User"
+          context: [CPE-OIDC]
+          filters: *filters
+      - aws-s3/sync:
+          name: Sync with args
+          pre-steps:
+            - run: cd ~/ && mkdir bucket && echo "lorem ipsum" > bucket/build_asset.txt
+          auth:
+            - aws-cli/setup:
+                role_arn: arn:aws:iam::122211685980:role/CPE_S3_OIDC_TEST
+                role_session_name: "Test-session"
+                profile_name: "OIDC-User"
+          from: "$HOME/bucket"
+          to: "s3://orb-testing-1/s3-orb"
+          profile_name: "OIDC-User"
+          arguments: "'--exclude *.hmtl' '--cache-control public,max-age=31536000,immutable'"
           context: [CPE-OIDC]
           filters: *filters
       - aws-s3/copy:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -55,7 +55,6 @@ workflows:
             parameters:
               executor: ["alpine", "docker-base"]
       - aws-s3/sync:
-          name: sync-simple
           pre-steps:
             - run: cd ~/ && mkdir bucket && echo "lorem ipsum" > bucket/build_asset.txt
           auth:
@@ -66,22 +65,12 @@ workflows:
           from: "$HOME/bucket"
           to: "s3://orb-testing-1/s3-orb"
           profile_name: "OIDC-User"
+          arguments: 
           context: [CPE-OIDC]
-          filters: *filters
-      - aws-s3/sync:
-          name: sync-with-args
-          pre-steps:
-            - run: cd ~/ && mkdir bucket && echo "lorem ipsum" > bucket/build_asset.txt
-          auth:
-            - aws-cli/setup:
-                role_arn: arn:aws:iam::122211685980:role/CPE_S3_OIDC_TEST
-                role_session_name: "Test-session"
-                profile_name: "OIDC-User"
-          from: "$HOME/bucket"
-          to: "s3://orb-testing-1/s3-orb"
-          profile_name: "OIDC-User"
-          arguments: "'--exclude *.hmtl' '--cache-control public,max-age=31536000,immutable'"
-          context: [CPE-OIDC]
+          matrix:
+            alias: sync
+            parameters:
+              arguments: ["'--exclude *.hmtl' '--cache-control public,max-age=31536000,immutable'", ""] 
           filters: *filters
       - aws-s3/copy:
           pre-steps:
@@ -97,7 +86,7 @@ workflows:
           context: [CPE-OIDC]
           filters: *filters
           requires:
-            - aws-s3/sync
+            - sync
       - orb-tools/pack:
           filters: *release-filters
       - orb-tools/publish:
@@ -105,6 +94,6 @@ workflows:
           vcs_type: << pipeline.project.type >>
           pub_type: production
           enable_pr_comment: true
-          requires: [orb-tools/pack, integration-test, aws-s3/copy, sync-simple, sync-with-args]
+          requires: [orb-tools/pack, integration-test, aws-s3/copy, sync]
           context: orb-publisher
           filters: *release-filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
-  orb-tools: circleci/orb-tools@12.0
-  aws-cli: circleci/aws-cli@4.0
+  orb-tools: circleci/orb-tools@12.1.1
+  aws-cli: circleci/aws-cli@5.1.1
   aws-s3: {}
 filters: &filters
   tags:

--- a/src/commands/copy.yml
+++ b/src/commands/copy.yml
@@ -14,7 +14,7 @@ parameters:
   profile_name:
     description: AWS profile name to be configured.
     type: string
-    default: "default"
+    default: ""
   role_arn:
     description: |
       The Amazon Resource Name (ARN) of the role that the caller is assuming.

--- a/src/commands/sync.yml
+++ b/src/commands/sync.yml
@@ -18,7 +18,7 @@ parameters:
   profile_name:
     description: AWS profile name to be configured.
     type: string
-    default: "default"
+    default: ""
   when:
     description: |
       Add the when attribute to a job step to override its default behavior

--- a/src/examples/authentication_with_jobs.yml
+++ b/src/examples/authentication_with_jobs.yml
@@ -7,7 +7,7 @@ usage:
   orbs:
     aws-s3: circleci/aws-s3@4.0
     # Importing aws-cli orb is required
-    aws-cli: circleci/aws-cli@4.0
+    aws-cli: circleci/aws-cli@5.1.1
   workflows:
     s3-example:
       jobs:

--- a/src/examples/override_credentials.yml
+++ b/src/examples/override_credentials.yml
@@ -5,7 +5,7 @@ usage:
   orbs:
     aws-s3: circleci/aws-s3@4.0
     # Importing aws-cli orb is required
-    aws-cli: circleci/aws-cli@4.0
+    aws-cli: circleci/aws-cli@5.1.1
   jobs:
     build:
       docker:

--- a/src/examples/sync_and_copy_with_oidc.yml
+++ b/src/examples/sync_and_copy_with_oidc.yml
@@ -9,7 +9,7 @@ usage:
   orbs:
     aws-s3: circleci/aws-s3@4.0
     # Importing aws-cli orb is required
-    aws-cli: circleci/aws-cli@4.0
+    aws-cli: circleci/aws-cli@5.1.1
   jobs:
     sync_and_copy:
       docker:

--- a/src/jobs/copy.yml
+++ b/src/jobs/copy.yml
@@ -14,7 +14,7 @@ parameters:
   profile_name:
     description: AWS profile name to be configured.
     type: string
-    default: "default"
+    default: ""
   auth:
     description: |
       The authentication method used to access your AWS account. Import the aws-cli orb in your config and

--- a/src/jobs/sync.yml
+++ b/src/jobs/sync.yml
@@ -14,7 +14,7 @@ parameters:
   profile_name:
     description: AWS profile name to be configured.
     type: string
-    default: "default"
+    default: ""
   auth:
     description: |
       The authentication method used to access your AWS account. Import the aws-cli orb in your config and

--- a/src/scripts/copy.sh
+++ b/src/scripts/copy.sh
@@ -8,10 +8,12 @@ if [ -n "${ORB_STR_ARGUMENTS}" ]; then
     IFS=' '
     set --
     for arg in $(echo "${ORB_STR_ARGUMENTS}" | sed 's/,[ ]*/,/g'); do
-    set -- "$@" "$arg"
+        set -- "$@" "$arg"
     done
 fi
-
+if [ -n "${ORB_STR_PROFILE_NAME}" ]; then
+    set -- "$@" --profile "${ORB_STR_PROFILE_NAME}"
+fi
 set -x
-aws s3 cp "${ORB_EVAL_FROM}" "${ORB_EVAL_TO}" --profile "${ORB_STR_PROFILE_NAME}" "$@"
+aws s3 cp "${ORB_EVAL_FROM}" "${ORB_EVAL_TO}" "$@"
 set +x

--- a/src/scripts/sync.sh
+++ b/src/scripts/sync.sh
@@ -13,7 +13,7 @@ if [ -n "${ORB_STR_ARGUMENTS}" ]; then
     done
 fi
 if [ -n "${ORB_STR_PROFILE_NAME}" ]; then
-    set -- "$@" --profile ${ORB_STR_PROFILE_NAME}
+    set -- "$@" --profile "${ORB_STR_PROFILE_NAME}"
 fi
 set -x
 aws s3 sync "${ORB_EVAL_FROM}" "${ORB_EVAL_TO}" "$@"

--- a/src/scripts/sync.sh
+++ b/src/scripts/sync.sh
@@ -9,9 +9,12 @@ if [ -n "${ORB_STR_ARGUMENTS}" ]; then
     IFS=' '
     set --
     for arg in $(echo "${ORB_STR_ARGUMENTS}" | sed 's/,[ ]*/,/g'); do
-    set -- "$@" "$arg"
+        set -- "$@" "$arg"
     done
 fi
+if [ -n "${ORB_STR_PROFILE_NAME}" ]; then
+    set -- "$@" "--profile ${ORB_STR_PROFILE_NAME}"
+fi
 set -x
-aws s3 sync "${ORB_EVAL_FROM}" "${ORB_EVAL_TO}" --profile "${ORB_STR_PROFILE_NAME}" "$@"
+aws s3 sync "${ORB_EVAL_FROM}" "${ORB_EVAL_TO}" "$@"
 set +x

--- a/src/scripts/sync.sh
+++ b/src/scripts/sync.sh
@@ -13,7 +13,7 @@ if [ -n "${ORB_STR_ARGUMENTS}" ]; then
     done
 fi
 if [ -n "${ORB_STR_PROFILE_NAME}" ]; then
-    set -- "$@" "--profile ${ORB_STR_PROFILE_NAME}"
+    set -- "$@" --profile ${ORB_STR_PROFILE_NAME}
 fi
 set -x
 aws s3 sync "${ORB_EVAL_FROM}" "${ORB_EVAL_TO}" "$@"


### PR DESCRIPTION
Resolves #57 
The scripts on this orb where always using the `--profile` flag, setting to default when not passed. This would work fine when using the aws-cli/setup for authentication as it always creates a profile, but would fail if someone only wanted to use the environment variables.
I'm making the flag optional and default to empty string, so it is only used when someone passes a profile name explicitly.
