### PR TITLE
Make auth not required

### DIFF
--- a/src/jobs/copy.yml
+++ b/src/jobs/copy.yml
@@ -19,7 +19,9 @@ parameters:
     description: |
       The authentication method used to access your AWS account. Import the aws-cli orb in your config and
       provide the aws-cli/setup command to authenticate with your preferred method. View examples for more information.
+      If not provided, authentication will be handled by the environment (e.g., IAM roles, environment variables).
     type: steps
+    default: []
   when:
     description: |
       Add the when attribute to a job step to override its default behavior
@@ -34,7 +36,9 @@ parameters:
 executor: << parameters.executor >>
 steps:
   - checkout
-  - steps: <<parameters.auth>>
+  - when:
+      condition: <<parameters.auth>>
+      steps: <<parameters.auth>>
   - copy:
       when: <<parameters.when>>
       from: <<parameters.from>>

--- a/src/jobs/sync.yml
+++ b/src/jobs/sync.yml
@@ -19,7 +19,9 @@ parameters:
     description: |
       The authentication method used to access your AWS account. Import the aws-cli orb in your config and
       provide the aws-cli/setup command to authenticate with your preferred method. View examples for more information.
+      If not provided, authentication will be handled by the environment (e.g., IAM roles, environment variables).
     type: steps
+    default: []
   when:
     description: |
       Add the when attribute to a job step to override its default behavior
@@ -34,7 +36,9 @@ parameters:
 executor: << parameters.executor >>
 steps:
   - checkout
-  - steps: <<parameters.auth>>
+  - when:
+      condition: <<parameters.auth>>
+      steps: <<parameters.auth>>
   - sync:
       when: <<parameters.when>>
       from: <<parameters.from>>


### PR DESCRIPTION
- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, Related Issues

Auth is not required (like shown in the docs examples), I have error in my IDE, but code is still working, because I do aws-cli/setup before than copy and sync (like shown in the docs examples).

### Description

Make auth not required in copy and sync commands